### PR TITLE
Hope to add a few more sysctl params

### DIFF
--- a/Sources/Sysctl/Base/ValueTypes.swift
+++ b/Sources/Sysctl/Base/ValueTypes.swift
@@ -49,6 +49,13 @@ extension CInt: SysctlValue {
     public typealias SysctlPointerType = Self
 }
 
+/// Make 64-bit C Integers conform to SysctlValue for
+/// large numbers (e.g., memsize)
+extension CLongLong: SysctlValue {
+    /// See `SysctlValue.SysctlPointerType`
+    public typealias SysctlPointerType = Self
+}
+
 extension timeval: SysctlValue {
     /// See `SysctlValue.SysctlPointerType`
     public typealias SysctlPointerType = Self

--- a/Sources/Sysctl/Namespaces/Hardware.swift
+++ b/Sources/Sysctl/Namespaces/Hardware.swift
@@ -13,6 +13,11 @@ public struct Hardware: SysctlNamespace {
 
     /// The number of CPUs (`ncpu`).
     public var numberOfCPUs: Field<CInt> { "ncpu" }
+    /// The user's number of physical cpus (`physicalcpu`).
+    public var physicalCPUs: Field<CInt> { "physicalcpu" }
+    
+    /// The user's memory size (`memsize`) in bytes.
+    public var memorySize: Field<CLongLong>  { "memsize" }
 }
 
 extension SysctlRootNamespace {

--- a/Sources/Sysctl/Namespaces/MachineDependent.swift
+++ b/Sources/Sysctl/Namespaces/MachineDependent.swift
@@ -1,0 +1,29 @@
+/// MachineDependent (`machdep`) namespace for Sysctl
+public struct MachineDependent: SysctlNamespace {
+    /// See SysctlNamespace
+    public typealias ParentNamespace = SysctlRootNamespace
+
+    /// See SysctlNamespace
+    public static var namePart: String { "machdep" }
+}
+
+extension MachineDependent {
+    /// The namespace for CPU  (`cpu`) values inside the machdep namespace.
+    public struct CPU: SysctlNamespace {
+        /// See SysctlNamespace
+        public typealias ParentNamespace = MachineDependent
+
+        /// See SysctlNamespace
+        public static var namePart: String { "cpu" }
+
+        /// The kind of cpu (`brand_string`).
+        public var brandString: Field<String> { "brand_string" }
+    }
+    
+    public var cpu: CPU { .init() }
+}
+
+extension SysctlRootNamespace {
+    /// The MachineDependent (`machdep`) part.
+    public var machineDependent: MachineDependent { .init() }
+}

--- a/Tests/SysctlTests/AccessTests.swift
+++ b/Tests/SysctlTests/AccessTests.swift
@@ -6,8 +6,22 @@ final class AccessTests: XCTestCase {
     private let sysctl = SystemControl()
 
     func testReading() {
+        // hardware
         XCTAssertFalse(sysctl.hardware.machine.isEmpty)
+        XCTAssertFalse(sysctl.hardware.model.isEmpty)
+        XCTAssertGreaterThan(sysctl.hardware.numberOfCPUs, 0)
+        XCTAssertGreaterThan(sysctl.hardware.physicalCPUs, 0)
+        XCTAssertFalse(sysctl.hardware.model.isEmpty)
+        // kernel
+        XCTAssertFalse(sysctl.kernel.kind.isEmpty)
+        XCTAssertFalse(sysctl.kernel.version.isEmpty)
+        XCTAssertFalse(sysctl.kernel.revision.isEmpty)
+        XCTAssertFalse(sysctl.kernel.fullVersionText.isEmpty)
+        XCTAssertGreaterThanOrEqual(sysctl.kernel.hostID, 0)
+        XCTAssertFalse(sysctl.kernel.hostname.isEmpty)
         XCTAssertLessThan(sysctl.kernel.bootDate, Date())
+        // machdep
+        XCTAssertFalse(sysctl.machineDependent.cpu.brandString.isEmpty)
     }
 
     func testWriting() throws {

--- a/Tests/SysctlTests/NameGenerationTests.swift
+++ b/Tests/SysctlTests/NameGenerationTests.swift
@@ -9,6 +9,8 @@ final class NameGenerationTests: XCTestCase {
         XCTAssertEqual(root.hardware.machine, "hw.machine")
         XCTAssertEqual(root.hardware.model, "hw.model")
         XCTAssertEqual(root.hardware.numberOfCPUs, "hw.ncpu")
+        XCTAssertEqual(root.hardware.physicalCPUs, "hw.physicalcpu")
+        XCTAssertEqual(root.hardware.memorySize, "hw.memsize")
     }
 
     func testKernelNamespace() {
@@ -22,6 +24,10 @@ final class NameGenerationTests: XCTestCase {
         XCTAssertEqual(root.kernel.osBuild, "kern.osversion")
         XCTAssertEqual(root.kernel.revision, "kern.osrevision")
         XCTAssertEqual(root.kernel.version, "kern.osrelease")
+    }
+    
+    func testMachdepNamespace() {
+        XCTAssertEqual(root.machineDependent.cpu.brandString, "machdep.cpu.brand_string")
     }
 
     func testNetworkingNamespace() {


### PR DESCRIPTION
Hi, thanks for writing this; it's well structured and neat.

Just needed a few more params. :D

1. Added CLongLong extension to support memsize.
2. Added Hardware variables for physicalcpu and memsize, as well as tests for same.
3. Added Machdep struct to add brandString.
4. Fleshed out tests; all are tested except isSingleUser. (Only reason I didn't write that one is that I wasn't sure what the assumptions should be; you'd almost always be running in non-single-user, though.)

Note: I didn't catch that autocorrect had bitten me and changed memsize to memorize in the commit. I was able to fix it in the PR, but didn't fix it in the commit. I could re-do it if you'd prefer.